### PR TITLE
Fix vhost stop failure when stop! called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache: bundler
 script: bundle exec rake travis
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
+  - 2.3.1
   - ruby-head
 
 before_install:

--- a/lib/phut/vhost.rb
+++ b/lib/phut/vhost.rb
@@ -68,7 +68,12 @@ module Phut
 
     def stop!
       fail "vhost (name = #{name}) is not running!" unless running?
-      sh "vhost stop -n #{name} -S #{Phut.socket_dir}"
+      if ENV['rvm_path']
+        sh "rvmsudo vhost stop -n #{name} -s #{Phut.socket_dir}"
+      else
+        vhost = File.join(__dir__, '..', '..', 'bin', 'vhost')
+        sh "bundle exec sudo #{vhost} stop -n #{name} -s #{Phut.socket_dir}"
+      end
     end
 
     def running?

--- a/phut.gemspec
+++ b/phut.gemspec
@@ -38,6 +38,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard-cucumber', '~> 2.0.0'
   gem.add_development_dependency 'guard-rspec', '~> 4.6.4'
   gem.add_development_dependency 'guard-rubocop', '~> 1.2.0'
+  # To support Ruby 2.1; Listen 3.1.0 or later does not run on Ruby 2.1
+  gem.add_development_dependency 'listen', '< 3.1.0'
 
   # Test
   gem.add_development_dependency 'aruba', '~> 0.11.2'


### PR DESCRIPTION
When `Vhost#stop!` called it fails because there is no `rvmsudo` or `bundle exec sudo`.
It is as same as 9e6e78a.