### PR TITLE
Add `mac` directive into Netns DSL.

### DIFF
--- a/features/dsl/netns.feature
+++ b/features/dsl/netns.feature
@@ -55,6 +55,24 @@ Feature: The netns DSL directive.
     And the netmask of the netns "host2" should be "255.255.255.128"
 
   @sudo
+  Scenario: mac option
+    Given a file named "phut.conf" with:
+      """
+      netns('host1') {
+        ip '192.168.0.1'
+        mac '00:00:ba:dc:ab:1e'
+      }
+      netns('host2') {
+        ip '192.168.0.2'
+        mac '00:ac:ce:55:1b:1e'
+      }
+      link 'host1', 'host2'
+      """
+    When I do phut run "phut.conf"
+    Then the MAC address of the netns "host1" should be "00:00:ba:dc:ab:1e"
+    And the MAC address of the netns "host2" should be "00:ac:ce:55:1b:1e"
+
+  @sudo
   Scenario: route option
     Given a file named "phut.conf" with:
       """

--- a/features/step_definitions/netns_steps.rb
+++ b/features/step_definitions/netns_steps.rb
@@ -11,6 +11,10 @@ Then(/^the IP address of the netns "([^"]*)" should be "([^"]*)"$/) do |name, ip
   expect(Phut::Netns.find_by!(name: name).ip_address).to eq ip
 end
 
+Then(/^the MAC address of the netns "([^"]*)" should be "([^"]*)"$/) do |name, mac|
+  expect(Phut::Netns.find_by!(name: name).mac_address).to eq mac
+end
+
 Then(/^the netmask of the netns "([^"]*)" should be "([^"]*)"$/) do |name, netmask|
   expect(Phut::Netns.find_by!(name: name).netmask).to eq netmask
 end

--- a/lib/phut/netns.rb
+++ b/lib/phut/netns.rb
@@ -15,18 +15,18 @@ module Phut
     def self.all
       sh('ip netns list').split("\n").map do |each|
         name = each.split.first
-        ip_addr_list = sudo("ip netns exec #{name} ip -4 -o addr list").split("\n")
-        mac_addr_list = sudo("ip netns exec #{name} ip -4 -o link list").split("\n")
+        ip_addr_list =
+          sudo("ip netns exec #{name} ip -4 -o addr list").split("\n")
+        mac_addr_list =
+          sudo("ip netns exec #{name} ip -4 -o link list").split("\n")
         if ip_addr_list.size > 1
           %r{inet ([^/]+)/(\d+)} =~ ip_addr_list[1]
           ip_address = Regexp.last_match(1)
-          netmask = IPAddr.new('255.255.255.255').mask(Regexp.last_match(2).to_i).to_s
-          %r{link/ether ((?:[\da-fA-F]{2}:){5}[\da-fA-F]{2})} =~ mac_addr_list[1]
-          mac_address = Regexp.last_match(1)
-          new(name: name,
-              mac_address: mac_address,
-              ip_address: ip_address,
-              netmask: netmask)
+          mask_length = Regexp.last_match(2).to_i
+          netmask = IPAddr.new('255.255.255.255').mask(mask_length).to_s
+          %r{link/ether ((?:[a-f\d]{2}:){5}[a-f\d]{2})}i =~ mac_addr_list[1]
+          new(name: name, ip_address: ip_address, netmask: netmask,
+              mac_address: Regexp.last_match(1))
         else
           new(name: name)
         end

--- a/lib/phut/netns.rb
+++ b/lib/phut/netns.rb
@@ -15,13 +15,18 @@ module Phut
     def self.all
       sh('ip netns list').split("\n").map do |each|
         name = each.split.first
-        addr_list = sudo("ip netns exec #{name} ip -4 -o addr list").split("\n")
-        if addr_list.size > 1
-          %r{inet ([^/]+)/(\d+)} =~ addr_list[1]
+        ip_addr_list = sudo("ip netns exec #{name} ip -4 -o addr list").split("\n")
+        mac_addr_list = sudo("ip netns exec #{name} ip -4 -o link list").split("\n")
+        if ip_addr_list.size > 1
+          %r{inet ([^/]+)/(\d+)} =~ ip_addr_list[1]
+          ip_address = Regexp.last_match(1)
+          netmask = IPAddr.new('255.255.255.255').mask(Regexp.last_match(2).to_i).to_s
+          %r{link/ether ((?:[\da-fA-F]{2}:){5}[\da-fA-F]{2})} =~ mac_addr_list[1]
+          mac_address = Regexp.last_match(1)
           new(name: name,
-              ip_address: Regexp.last_match(1),
-              netmask: IPAddr.new('255.255.255.255').
-                       mask(Regexp.last_match(2).to_i).to_s)
+              mac_address: mac_address,
+              ip_address: ip_address,
+              netmask: netmask)
         else
           new(name: name)
         end
@@ -106,7 +111,6 @@ module Phut
       sudo "ip netns exec #{name} "\
            "ip addr replace #{@ip_address}/#{@netmask} "\
            "dev #{device_name}#{vlan_suffix}"
-
       sudo "ip netns exec #{name} ip link set #{device_name}#{vlan_suffix} up"
 
       @route.add name

--- a/lib/phut/parser.rb
+++ b/lib/phut/parser.rb
@@ -31,7 +31,7 @@ module Phut
           Netns.create(name: each[:name],
                        ip_address: each[:ip], netmask: each[:netmask],
                        route: { net: each[:net], gateway: each[:gateway] },
-                       vlan: each[:vlan])
+                       mac_address: each[:mac_address], vlan: each[:vlan])
         netns.device = find_network_device(each.name)
       end
     end

--- a/lib/phut/syntax/netns_directive.rb
+++ b/lib/phut/syntax/netns_directive.rb
@@ -23,6 +23,10 @@ module Phut
         @attributes[:gateway] = options.fetch(:gateway)
       end
 
+      def mac(value)
+        @attributes[:mac_address] = value
+      end
+
       def vlan(value)
         @attributes[:vlan] = value
       end


### PR DESCRIPTION
* `Phut.#all` で host namespace 内のインタフェースMACアドレスを取得して返すように変更。
* Netns DSL に `mac` directive を追加。
* `netns.feature` で MAC Address の設定とチェックのテストを追加。